### PR TITLE
Add keybind to open panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
     },
     "main": "./out/extension/extension.js",
     "contributes": {
+        "keybindings": [
+            {
+                "command": "waypoint.showPanel",
+                "key": "ctrl+k y"
+            }
+        ],
         "commands": [
             {
                 "command": "waypoint.showPanel",


### PR DESCRIPTION
On `CTRL+K Y`, the waypoint panel will now open. 

I thought of `CTRL+K W` but it is already in use by VSCode to close the editor.

let me know if anything needs to be changed.

Resolves #16